### PR TITLE
Implement Better Game Menu Support

### DIFF
--- a/EventMarker.cs
+++ b/EventMarker.cs
@@ -27,16 +27,13 @@ namespace MapEventMarkersMod
             }
         }
 
-        public string GetHoverText(GameMenu gameMenu, Vector2 topLeft)
+        public string GetHoverText(MapPage mapPage, Vector2 topLeft)
         {
-            int mapTabIndex = Constants.TargetPlatform == GamePlatform.Android ? 4 : GameMenu.mapTab;
             string hoverText = "";
-            
-                MapPage mapPage = (MapPage)gameMenu.pages[mapTabIndex];
 
-                foreach (ClickableComponent point in mapPage.points.Values)
-                    if (point.containsPoint(Game1.getMouseX(true), Game1.getMouseY(true)))
-                        hoverText = point.label;
+            foreach (ClickableComponent point in mapPage.points.Values)
+                if (point.containsPoint(Game1.getMouseX(true), Game1.getMouseY(true)))
+                    hoverText = point.label;
 
             return hoverText;
         }

--- a/IBetterGameMenu.cs
+++ b/IBetterGameMenu.cs
@@ -1,119 +1,8 @@
 ﻿#nullable enable
 
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-
-using StardewModdingAPI.Events;
-
-using StardewValley;
 using StardewValley.Menus;
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Leclair.Stardew.BetterGameMenu;
-
-
-/// <summary>
-/// This interface represents a Better Game Menu. 
-/// </summary>
-public interface IBetterGameMenu
-{
-    /// <summary>
-    /// The <see cref="IClickableMenu"/> instance for this game menu. This is
-    /// the same object, but with a different type. This property is included
-    /// for convenience due to how API proxying works.
-    /// </summary>
-    IClickableMenu Menu { get; }
-
-    /// <summary>
-    /// Whether or not the menu is currently drawing itself. This is typically
-    /// always <c>false</c> except when viewing the <c>Map</c> tab.
-    /// </summary>
-    bool Invisible { get; set; }
-
-    /// <summary>
-    /// A list of ids of the currently visible tabs.
-    /// </summary>
-    IReadOnlyList<string> VisibleTabs { get; }
-
-    /// <summary>
-    /// The id of the currently active tab.
-    /// </summary>
-    string CurrentTab { get; }
-
-    /// <summary>
-    /// The <see cref="IClickableMenu"/> instance for the currently active tab.
-    /// This may be <c>null</c> if the page instance for the currently active
-    /// tab is still being initialized.
-    /// </summary>
-    IClickableMenu? CurrentPage { get; }
-
-    /// <summary>
-    /// Whether or not the currently displayed page is an error page. Error
-    /// pages are used when a tab implementation's GetPageInstance method
-    /// throws an exception.
-    /// </summary>
-    bool CurrentTabHasErrored { get; }
-
-    /// <summary>
-    /// Try to get the source for the specific tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to get the source of.</param>
-    /// <param name="source">The unique ID of the mod that registered the
-    /// implementation being used, or <c>stardew</c> if the base game's
-    /// implementation is being used.</param>
-    /// <returns>Whether or not the tab is registered with the system.</returns>
-    bool TryGetSource(string target, [NotNullWhen(true)] out string? source);
-
-    /// <summary>
-    /// Try to get the <see cref="IClickableMenu"/> instance for a specific tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to get the page for.</param>
-    /// <param name="page">The page instance, if one exists.</param>
-    /// <param name="forceCreation">If set to true, an instance will attempt to
-    /// be created if one has not already been created.</param>
-    /// <returns>Whether or not a page instance for that tab exists.</returns>
-    bool TryGetPage(string target, [NotNullWhen(true)] out IClickableMenu? page, bool forceCreation = false);
-
-    /// <summary>
-    /// Attempt to change the currently active tab to the target tab.
-    /// </summary>
-    /// <param name="target">The id of the tab to change to.</param>
-    /// <param name="playSound">Whether or not to play a sound.</param>
-    /// <returns>Whether or not the tab was changed successfully.</returns>
-    bool TryChangeTab(string target, bool playSound = true);
-
-    /// <summary>
-    /// Force the menu to recalculate the visible tabs. This will not recreate
-    /// <see cref="IClickableMenu"/> instances, but can be used to cause an
-    /// inactive tab to be removed, or a previously hidden tab to be added.
-    /// This can also be used to update tab decorations if necessary.
-    /// </summary>
-    /// <param name="target">Optionally, a specific tab to update rather than
-    /// updating all tabs.</param>
-    void UpdateTabs(string? target = null);
-
-}
-
-
-/// <summary>
-/// This enum is included for reference and has the order value for
-/// all the default tabs from the base game. These values are intentionally
-/// spaced out to allow for modded tabs to be inserted at specific points.
-/// </summary>
-public enum VanillaTabOrders
-{
-    Inventory = 0,
-    Skills = 20,
-    Social = 40,
-    Map = 60,
-    Crafting = 80,
-    Animals = 100,
-    Powers = 120,
-    Collections = 140,
-    Options = 160,
-    Exit = 200
-}
 
 
 public interface IBetterGameMenuApi
@@ -122,18 +11,10 @@ public interface IBetterGameMenuApi
     #region Menu Class Access
 
     /// <summary>
-    /// The active screen's current Better Game Menu, if one is open,
-    /// else <c>null</c>.
-    /// </summary>
-    IBetterGameMenu? ActiveMenu { get; }
-
-    /// <summary>
-    /// Attempt to cast the provided menu into an <see cref="IBetterGameMenu"/>.
-    /// This can be useful if you're working with a menu that isn't currently
-    /// assigned to <see cref="Game1.activeClickableMenu"/>.
-    /// </summary>
-    /// <param name="menu">The menu to attempt to cast</param>
-    IBetterGameMenu? AsMenu(IClickableMenu menu);
+	/// The current page of the active screen's current Better Game Menu,
+	/// if one is open, else <c>null</c>.
+	/// </summary>
+	IClickableMenu? ActivePage { get; }
 
     #endregion
 

--- a/IBetterGameMenu.cs
+++ b/IBetterGameMenu.cs
@@ -1,0 +1,140 @@
+﻿#nullable enable
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+using StardewModdingAPI.Events;
+
+using StardewValley;
+using StardewValley.Menus;
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Leclair.Stardew.BetterGameMenu;
+
+
+/// <summary>
+/// This interface represents a Better Game Menu. 
+/// </summary>
+public interface IBetterGameMenu
+{
+    /// <summary>
+    /// The <see cref="IClickableMenu"/> instance for this game menu. This is
+    /// the same object, but with a different type. This property is included
+    /// for convenience due to how API proxying works.
+    /// </summary>
+    IClickableMenu Menu { get; }
+
+    /// <summary>
+    /// Whether or not the menu is currently drawing itself. This is typically
+    /// always <c>false</c> except when viewing the <c>Map</c> tab.
+    /// </summary>
+    bool Invisible { get; set; }
+
+    /// <summary>
+    /// A list of ids of the currently visible tabs.
+    /// </summary>
+    IReadOnlyList<string> VisibleTabs { get; }
+
+    /// <summary>
+    /// The id of the currently active tab.
+    /// </summary>
+    string CurrentTab { get; }
+
+    /// <summary>
+    /// The <see cref="IClickableMenu"/> instance for the currently active tab.
+    /// This may be <c>null</c> if the page instance for the currently active
+    /// tab is still being initialized.
+    /// </summary>
+    IClickableMenu? CurrentPage { get; }
+
+    /// <summary>
+    /// Whether or not the currently displayed page is an error page. Error
+    /// pages are used when a tab implementation's GetPageInstance method
+    /// throws an exception.
+    /// </summary>
+    bool CurrentTabHasErrored { get; }
+
+    /// <summary>
+    /// Try to get the source for the specific tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to get the source of.</param>
+    /// <param name="source">The unique ID of the mod that registered the
+    /// implementation being used, or <c>stardew</c> if the base game's
+    /// implementation is being used.</param>
+    /// <returns>Whether or not the tab is registered with the system.</returns>
+    bool TryGetSource(string target, [NotNullWhen(true)] out string? source);
+
+    /// <summary>
+    /// Try to get the <see cref="IClickableMenu"/> instance for a specific tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to get the page for.</param>
+    /// <param name="page">The page instance, if one exists.</param>
+    /// <param name="forceCreation">If set to true, an instance will attempt to
+    /// be created if one has not already been created.</param>
+    /// <returns>Whether or not a page instance for that tab exists.</returns>
+    bool TryGetPage(string target, [NotNullWhen(true)] out IClickableMenu? page, bool forceCreation = false);
+
+    /// <summary>
+    /// Attempt to change the currently active tab to the target tab.
+    /// </summary>
+    /// <param name="target">The id of the tab to change to.</param>
+    /// <param name="playSound">Whether or not to play a sound.</param>
+    /// <returns>Whether or not the tab was changed successfully.</returns>
+    bool TryChangeTab(string target, bool playSound = true);
+
+    /// <summary>
+    /// Force the menu to recalculate the visible tabs. This will not recreate
+    /// <see cref="IClickableMenu"/> instances, but can be used to cause an
+    /// inactive tab to be removed, or a previously hidden tab to be added.
+    /// This can also be used to update tab decorations if necessary.
+    /// </summary>
+    /// <param name="target">Optionally, a specific tab to update rather than
+    /// updating all tabs.</param>
+    void UpdateTabs(string? target = null);
+
+}
+
+
+/// <summary>
+/// This enum is included for reference and has the order value for
+/// all the default tabs from the base game. These values are intentionally
+/// spaced out to allow for modded tabs to be inserted at specific points.
+/// </summary>
+public enum VanillaTabOrders
+{
+    Inventory = 0,
+    Skills = 20,
+    Social = 40,
+    Map = 60,
+    Crafting = 80,
+    Animals = 100,
+    Powers = 120,
+    Collections = 140,
+    Options = 160,
+    Exit = 200
+}
+
+
+public interface IBetterGameMenuApi
+{
+
+    #region Menu Class Access
+
+    /// <summary>
+    /// The active screen's current Better Game Menu, if one is open,
+    /// else <c>null</c>.
+    /// </summary>
+    IBetterGameMenu? ActiveMenu { get; }
+
+    /// <summary>
+    /// Attempt to cast the provided menu into an <see cref="IBetterGameMenu"/>.
+    /// This can be useful if you're working with a menu that isn't currently
+    /// assigned to <see cref="Game1.activeClickableMenu"/>.
+    /// </summary>
+    /// <param name="menu">The menu to attempt to cast</param>
+    IBetterGameMenu? AsMenu(IClickableMenu menu);
+
+    #endregion
+
+}

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -1,4 +1,6 @@
-﻿using LightRadiusMod;
+﻿using Leclair.Stardew.BetterGameMenu;
+
+using LightRadiusMod;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
@@ -23,7 +25,9 @@ namespace MapEventMarkersMod
         /// <summary>The mod configuration from the player.</summary>
         private ModConfig Config;
         private List<GameLocation>? PendingEvents;
-        
+
+        private IBetterGameMenuApi? BetterGameMenu;
+
         /*********
          ** Public methods
          *********/
@@ -43,10 +47,20 @@ namespace MapEventMarkersMod
          ** Private methods
          *********/
 
+        private MapPage? GetMapPage()
+        {
+            if (BetterGameMenu?.ActiveMenu?.CurrentPage is MapPage page)
+                return page;
+
+            if (Game1.activeClickableMenu is GameMenu gm && gm.GetCurrentPage() is MapPage mp)
+                return mp;
+
+            return null;
+        }
+
         private void OnMenuChanged(object sender, MenuChangedEventArgs e)
         {
-            int mapTabIndex = Constants.TargetPlatform == GamePlatform.Android ? 4 : GameMenu.mapTab;
-            if (Game1.activeClickableMenu is not GameMenu gameMenu || gameMenu.currentTab != mapTabIndex)
+            if (GetMapPage() == null)
             {
                 PendingEvents = null;
                 return;
@@ -62,8 +76,7 @@ namespace MapEventMarkersMod
             if (!Config.Enabled)
                 return;
             
-            int mapTabIndex = Constants.TargetPlatform == GamePlatform.Android ? 4 : GameMenu.mapTab;
-            if (Game1.activeClickableMenu is not GameMenu gameMenu || gameMenu.currentTab != mapTabIndex)
+            if (GetMapPage() == null)
                 return;
 
             PendingEvents ??= GetPendingEvents();
@@ -132,21 +145,20 @@ namespace MapEventMarkersMod
 
         private void DrawMarker(GameLocation location)
         {
-            int mapTabIndex = Constants.TargetPlatform == GamePlatform.Android ? 4 : GameMenu.mapTab;
-            if (Game1.activeClickableMenu is not GameMenu gameMenu || gameMenu.currentTab != mapTabIndex)
+            if (GetMapPage() is not MapPage Map)
                 return;
-            Rectangle mapBounds = ((MapPage)gameMenu.pages[GameMenu.mapTab]).mapBounds;
+
+            Rectangle mapBounds = Map.mapBounds;
 
             Vector2 mapVec = Utility.getTopLeftPositionForCenteringOnScreen(mapBounds.Width * 4, mapBounds.Height * 4);
 
             SpriteBatch spriteBatch = Game1.spriteBatch;
-            
-            MapPage Map = (MapPage)((GameMenu)Game1.activeClickableMenu).pages[mapTabIndex];
+
             MapAreaPositionWithContext? markerPosition = WorldMapManager.GetPositionData(location, new Point(0, 0)) ?? WorldMapManager.GetPositionData(Game1.getFarm(), Point.Zero);
             
             EventMarker eventMarker = new EventMarker(location);
 
-            var childMenu = gameMenu.GetChildMenu();
+            var childMenu = Game1.activeClickableMenu.GetChildMenu();
             
             if (childMenu is not null && childMenu.GetType().FullName == "RidgesideVillage.RSVWorldMap" 
                                       && markerPosition.Value.Data.Region.Id == "Rafseazz.RSVCP_RidgesideVillage")
@@ -180,15 +192,23 @@ namespace MapEventMarkersMod
             
             if ((mouseVec - position).Length() < radius) 
                 IClickableMenu.drawHoverText(spriteBatch, $"Event in {location.DisplayName}", Game1.smallFont, yOffset: -70);
-            
+
             if (childMenu is not null)
                 childMenu.drawMouse(spriteBatch);
             else
-                gameMenu.drawMouse(spriteBatch);
+                Game1.activeClickableMenu.drawMouse(spriteBatch);
         }
         
         private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
         {
+            try
+            {
+                BetterGameMenu = this.Helper.ModRegistry.GetApi<IBetterGameMenuApi>("leclair.bettergamemenu");
+            } catch (Exception ex)
+            {
+                this.Monitor.Log($"Error getting Better Game Menu API: {ex}", LogLevel.Warn);
+            }
+
             var configMenu = this.Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
             if (configMenu is null)
                 return;

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -49,7 +49,7 @@ namespace MapEventMarkersMod
 
         private MapPage? GetMapPage()
         {
-            if (BetterGameMenu?.ActiveMenu?.CurrentPage is MapPage page)
+            if (BetterGameMenu?.ActivePage is MapPage page)
                 return page;
 
             if (Game1.activeClickableMenu is GameMenu gm && gm.GetCurrentPage() is MapPage mp)


### PR DESCRIPTION
Hello!

[Better Game Menu](https://github.com/KhloeLeclair/StardewMods/releases/tag/BetterGameMenu-Preview2) is a new mod I'm going to be releasing that replaces `GameMenu` with a replacement that:

1. Is considerably more efficient by virtue of only creating page instances when the pages are actually accessed.
2. Has a robust API to let other mods work with the game menu, making it easy to register new tabs, override existing tabs, and respond to events involving the menu.

I realize this has the potential to break a lot of things, so I'm going to be submitting PRs to various mods that interact with GameMenu to implement support for BetterGameMenu. This is such a PR.

---

I refactored your code a little here. I'm not sure why you were checking for the currently active tab based on index like you were, when it really comes down to whether or not the current page is a `MapPage` instance? But from my testing this works fine. The refactor also made it a lot simpler to add Better Game Menu support, since the `GameMenu` access is all in a single method.

I hope this helps, and thank you for your cooperation. I know something like replacing `GameMenu` is a big thing to drop on people but I think it'll be worth it in the long run.